### PR TITLE
Fix readme link and player textarea

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Un jeu de débat politique interactif où vous affrontez une IA sur des sujets clivants. Développé avec TypeScript, Vite et l'API Google Generative AI (Gemini).
 
 [![Deploy Status](https://github.com/your-username/political-madness/actions/workflows/deploy.yml/badge.svg)](https://github.com/your-username/political-madness/actions/workflows/deploy.yml)
-[![Live Demo](https://img.shields.io/badge/🚀-Live%20Demo-blue?style=for-the-badge)](https://your-username.github.io/political-madness/)
+[![Live Demo](https://img.shields.io/badge/🚀-Live%20Demo-blue?style=for-the-badge)](https://insomniak313.github.io/Political-Madness/)
 
-> **🎮 [Jouer maintenant](https://your-username.github.io/political-madness/)** - Version en ligne déployée automatiquement
+> **🎮 [Jouer maintenant](https://insomniak313.github.io/Political-Madness/)** - Version en ligne déployée automatiquement
 
 ## 🚀 Fonctionnalités
 
@@ -51,7 +51,7 @@ Un jeu de débat politique interactif où vous affrontez une IA sur des sujets c
 ### 🌐 Version en ligne (recommandée)
 
 Le site est automatiquement déployé sur GitHub Pages à chaque push sur la branche `main` :
-- **URL** : https://your-username.github.io/political-madness/
+- **URL** : https://insomniak313.github.io/Political-Madness/
 - **Déploiement automatique** : ✅ Activé via GitHub Actions
 - **Mise à jour** : Automatique à chaque merge sur `main`
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       showLoadingState();
       await game.initializeGame(config);
+      hideLoadingState();
       showGameScreen();
       showNotification(`Bienvenue ${config.playerName} ! Le débat commence.`, 'success');
     } catch (error) {
@@ -159,10 +160,17 @@ document.addEventListener('DOMContentLoaded', () => {
   function showGameScreen(): void {
     splashScreen.classList.add('hidden');
     gameScreen.classList.remove('hidden');
+    // S'assurer que le textarea est activé quand le jeu commence
+    playerInput.disabled = false;
+    sendResponse.disabled = false;
   }
 
   function hideSummaryModal(): void {
     summaryModal.classList.add('hidden');
+    // Réactiver le textarea après la fermeture du modal
+    playerInput.disabled = false;
+    sendResponse.disabled = false;
+    playerInput.focus();
   }
 
   function hideGameOverModal(): void {
@@ -184,6 +192,9 @@ document.addEventListener('DOMContentLoaded', () => {
     sendResponse.disabled = false;
     sendResponse.innerHTML = 'Envoyer';
     playerInput.disabled = false;
+    
+    // S'assurer que le textarea est focusable
+    playerInput.focus();
   }
 
   function showNotification(message: string, type: NotificationType = 'info'): void {


### PR DESCRIPTION
Update live demo link in README and fix player textarea being disabled at game start.

The player's textarea was initially disabled because `hideLoadingState()` was not consistently called after game initialization or other state transitions. This PR ensures the textarea is correctly enabled and focused at game start, after responses, and upon closing the summary modal, allowing immediate player interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-b795362d-7555-40b4-a947-e15ea7f39d86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b795362d-7555-40b4-a947-e15ea7f39d86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

